### PR TITLE
The script should only listen to the channel, not nodeid

### DIFF
--- a/dassmusik.py
+++ b/dassmusik.py
@@ -76,7 +76,7 @@ while len( data ):
     piz.push( data )
 
     for (id, ext, f, data) in untilNone( piz.pop ):
-        if id  == 0x14006401: #Toanod
+        if (id & 0xFFFFFF00)  == 0x14006400: # type=chn, chn=toanod 0x0064
             newState = data[1]
             if newState != oldState: # Changed state
                 if newState == 0:


### PR DESCRIPTION
The pkt id is formatted as following masks:
0x1e000000 => packet type, for CHN = 0x14000000
0x01000000 => always zero (should be tested, 1 is for future use)
0x00FFFF00 => channel id
0x00000011 => sender id, should only be used for debugging

So simply mask out so we don't use sender id.

Havn't really tried the code yet, but it should work... I think. Could really only be tested in place
